### PR TITLE
Improve Min max parameters

### DIFF
--- a/SpecificDateTime/ControlManifest.Input.xml
+++ b/SpecificDateTime/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest>
-  <control namespace="RBH" constructor="SpecificDateTime" version="1.0.0" display-name-key="SpecificDateTime" description-key="SpecificDateTime description" control-type="standard" >
+  <control namespace="RBHx" constructor="SpecificDateTime" version="0.0.2" display-name-key="SpecificDateTimex" description-key="SpecificDateTime description" control-type="standard" >
     <!--external-service-usage node declares whether this 3rd party PCF control is using external service or not, if yes, this control will be considered as premium and please also add the external domain it is using.
     If it is not using any external service, please set the enabled="false" and DO NOT add any domain below. The "enabled" will be false by default.
     Example1:
@@ -19,8 +19,8 @@
     </external-service-usage>
     <!-- property node identifies a specific, configurable piece of data that the control expects from CDS -->
     <property name="SpecificDateTimeField" display-name-key="Date Time" description-key="Field mapped to custom control" of-type="DateAndTime.DateAndTime" usage="bound" required="true" />
-    <property name="MinDate" display-name-key="Minimum Date" description-key="Earliest date accepted by control" of-type="DateAndTime.DateAndTime" usage="input" required="false"/>
-    <property name="MaxDate" display-name-key="Maximum Date" description-key="Latest date accepted by control" of-type="DateAndTime.DateAndTime" usage="input" required="false"/>
+    <property name="MinDate" display-name-key="Minimum Date" description-key="Earliest date (ISO format) accepted by control or +/- days offset from current date+time" of-type="SingleLine.Text" usage="input" required="false"/>
+    <property name="MaxDate" display-name-key="Maximum Date" description-key="Latest date (ISO format) accepted by control or +/- days offset from current date+time" of-type="SingleLine.Text" usage="input" required="false"/>
     <!--
       Property node's of-type attribute can be of-type-group attribute.
       Example:

--- a/SpecificDateTime/ControlManifest.Input.xml
+++ b/SpecificDateTime/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest>
-  <control namespace="RBHx" constructor="SpecificDateTime" version="0.0.2" display-name-key="SpecificDateTimex" description-key="SpecificDateTime description" control-type="standard" >
+  <control namespace="RBHx" constructor="SpecificDateTime" version="0.0.3" display-name-key="SpecificDateTimex" description-key="SpecificDateTime description" control-type="standard" >
     <!--external-service-usage node declares whether this 3rd party PCF control is using external service or not, if yes, this control will be considered as premium and please also add the external domain it is using.
     If it is not using any external service, please set the enabled="false" and DO NOT add any domain below. The "enabled" will be false by default.
     Example1:

--- a/SpecificDateTime/ControlManifest.Input.xml
+++ b/SpecificDateTime/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest>
-  <control namespace="RBHx" constructor="SpecificDateTime" version="0.0.3" display-name-key="SpecificDateTimex" description-key="SpecificDateTime description" control-type="standard" >
+  <control namespace="RBH" constructor="SpecificDateTime" version="1.1.0" display-name-key="SpecificDateTime" description-key="SpecificDateTime description" control-type="standard" >
     <!--external-service-usage node declares whether this 3rd party PCF control is using external service or not, if yes, this control will be considered as premium and please also add the external domain it is using.
     If it is not using any external service, please set the enabled="false" and DO NOT add any domain below. The "enabled" will be false by default.
     Example1:

--- a/SpecificDateTime/index.ts
+++ b/SpecificDateTime/index.ts
@@ -118,10 +118,39 @@ export class SpecificDateTime implements ComponentFramework.StandardControl<IInp
             } else {
                 date = new Date(Date.now() + offset * 24 * 60 * 60 * 1000);
             }
-            return date;
+            if (Number.isNaN(date.getTime())) {
+                return undefined;
+            } else {
+                return date;
+            }
         }
         return date;
     }
+
+    /**
+     * Format two dates into a range that can be displayed to the user (either date may be undefined)
+     * @param lowBound lower bound (or undefined)
+     * @param highBound  upper date bound (or undefined)
+     * @returns 
+     */
+    private formatDateRange( lowBound: Date | undefined, highBound: Date | undefined) : string {
+        let rv = "Enter any valid date";
+        let lowString = lowBound?.toLocaleDateString();
+        let highString = highBound?.toLocaleDateString();
+        if ( lowBound && highBound ) {
+            rv = `Enter a date between ${lowString} and ${highString}`;
+        } else {
+            if ( !lowBound && highBound ) {
+                rv = `Enter a date before ${highString}`;
+            } else {
+                if (lowBound && ! highBound ) {
+                    rv = `Enter a date after ${lowString}`;
+                }
+            }
+        }
+        return rv;
+    }
+
 
     /**
      * Used to initialize the control instance. Controls can kick off remote server calls and other initialization actions here.
@@ -159,7 +188,7 @@ export class SpecificDateTime implements ComponentFramework.StandardControl<IInp
         this.dateInputElement.setAttribute("min", this._earliestDate?.toISOString().split("T")[0] ?? "");
         this.dateInputElement.setAttribute("data-testid", "date");
         this.dateInputElement.setAttribute("max", this._latestDate?.toISOString().split("T")[0] ?? "");
-        const title = "test"; // `Enter a date between ${this._earliestDate} and ${this._latestDate}`;
+        const title = this.formatDateRange( this._earliestDate, this._latestDate );
         this.dateInputElement.setAttribute("title", title);
 
         this.timeInputElement = document.createElement("input");

--- a/SpecificDateTime/index.ts
+++ b/SpecificDateTime/index.ts
@@ -103,6 +103,27 @@ export class SpecificDateTime implements ComponentFramework.StandardControl<IInp
     }
 
     /**
+     *
+     * @param input Process the input "date" parameter that will be either a date (in a format recognised by the
+     *              Javascript Date() constructor) or an offset in days from the current date.
+     * @returns
+     */
+    private processDateParameter(input: string | undefined): Date | undefined {
+        let date: Date | undefined = undefined;
+        if (input) {
+            // If the input is a number
+            const offset = Number(input);
+            if (Number.isNaN(offset)) {
+                date = new Date(input);
+            } else {
+                date = new Date(Date.now() + offset * 24 * 60 * 60 * 1000);
+            }
+            return date;
+        }
+        return date;
+    }
+
+    /**
      * Used to initialize the control instance. Controls can kick off remote server calls and other initialization actions here.
      * Data-set values are not initialized here, use updateView.
      * @param context The entire property bag available to control via Context Object; It contains values as set up by the customizer mapped to property names defined in the manifest, as well as utility functions.
@@ -122,8 +143,8 @@ export class SpecificDateTime implements ComponentFramework.StandardControl<IInp
         this._dateRefreshed = this.dateUpdated.bind(this);
         this._timeRefreshed = this.timeUpdated.bind(this);
 
-        this._earliestDate = context.parameters.MinDate?.raw ?? undefined;
-        this._latestDate = context.parameters.MaxDate?.raw ?? undefined;
+        this._earliestDate = this.processDateParameter(context.parameters.MinDate?.raw ?? undefined);
+        this._latestDate = this.processDateParameter(context.parameters.MaxDate?.raw ?? undefined);
 
         // To display the control we create and populate a div with a date and time input control and then
         // attach to the "container" element passed in from the environment.
@@ -135,11 +156,11 @@ export class SpecificDateTime implements ComponentFramework.StandardControl<IInp
         this.dateInputElement.addEventListener("input", this._dateRefreshed);
         this.dateInputElement.setAttribute("class", "dateControl");
         this.dateInputElement.setAttribute("id", "dateInput");
-        this.dateInputElement.setAttribute("min", "2023-01-01");
+        this.dateInputElement.setAttribute("min", this._earliestDate?.toISOString().split("T")[0] ?? "");
         this.dateInputElement.setAttribute("data-testid", "date");
-        const nextMonth = new Date(Date.now() + ONEDAY);
-        this.dateInputElement.setAttribute("max", nextMonth.toISOString().split("T")[0]);
-        this.dateInputElement.setAttribute("title", context.mode.isControlDisabled ? "disabled" : "enabled");
+        this.dateInputElement.setAttribute("max", this._latestDate?.toISOString().split("T")[0] ?? "");
+        const title = "test"; // `Enter a date between ${this._earliestDate} and ${this._latestDate}`;
+        this.dateInputElement.setAttribute("title", title);
 
         this.timeInputElement = document.createElement("input");
         this.timeInputElement.setAttribute("type", "time");
@@ -156,10 +177,10 @@ export class SpecificDateTime implements ComponentFramework.StandardControl<IInp
 
     /**
      * Called when any value in the property bag has changed. This includes field values, data-sets, global values such as container height and width, offline status, control metadata values such as label, visible, etc.
-     * 
+     *
      * Note that we need to be very careful here with the date value returned from the PCF framework. This will **not** be the same as the one we returned from getOutputs().
      * It needs to be adjusted by the CRM user's timezone offset and the locale timezone offset before we try to use it in the control.
-     * 
+     *
      * @param context The entire property bag available to control via Context Object; It contains values as set up by the customizer mapped to names defined in the manifest, as well as utility functions
      */
     public updateView(context: ComponentFramework.Context<IInputs>): void {

--- a/SpecificDateTime/tests/SpecificDatePicker2.test.ts
+++ b/SpecificDateTime/tests/SpecificDatePicker2.test.ts
@@ -26,8 +26,8 @@ describe( 'Testing SpecificDatePicker functions', () => {
         container = screen.getByTestId("container") as  HTMLDivElement;
         context.parameters.MinDate = mock<IInputs["MinDate"]>();
         context.parameters.MaxDate = mock<IInputs["MaxDate"]>();
-        context.parameters.MinDate.raw = new  Date('2024-01-01T00:00');
-        context.parameters.MaxDate.raw = new  Date('2024-05-01T00:00');
+        context.parameters.MinDate.raw = '2024-01-01T00:00';
+        context.parameters.MaxDate.raw = '2024-05-01T00:00';
         
         datePicker.init(context, outputChanged,state, container);
 

--- a/SpecificDateTime/tests/SpecificDatePicker3.test.ts
+++ b/SpecificDateTime/tests/SpecificDatePicker3.test.ts
@@ -30,8 +30,8 @@ describe( 'Testing Clearing the SpecificDatePicker', () => {
         container = screen.getByTestId("container") as  HTMLDivElement;
         context.parameters.MinDate = mock<IInputs["MinDate"]>();
         context.parameters.MaxDate = mock<IInputs["MaxDate"]>();
-        context.parameters.MinDate.raw = new  Date('2024-01-01T00:00');
-        context.parameters.MaxDate.raw = new  Date('2024-05-01T00:00');
+        context.parameters.MinDate.raw = '2024-01-01T00:00';
+        context.parameters.MaxDate.raw = '2024-05-01T00:00';
         
         datePicker.init(context, outputChanged,state, container);
 

--- a/SpecificDateTime/tests/SpecificDatePicker4.test.ts
+++ b/SpecificDateTime/tests/SpecificDatePicker4.test.ts
@@ -1,0 +1,115 @@
+import { SpecificDateTime } from '../index';
+import mock from "jest-mock-extended/lib/Mock";
+import { IInputs } from "../generated/ManifestTypes";
+import { getByTestId, waitFor } from '@testing-library/dom';
+import  '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+
+describe( 'Test min/max date features', () => {
+    const rbh_interactionId = "20000000-14fb-4fcb-93ea-bf3a7e0bdc25";
+
+    var datePicker : SpecificDateTime;
+    var container: HTMLDivElement;
+    var outputChanged: jest.Mock<any,any,any>;
+    var context: ComponentFramework.Context<IInputs>;
+    var state: ComponentFramework.Dictionary;
+    beforeEach(()=>{
+        userEvent.setup();
+        datePicker = new SpecificDateTime();
+        context = mock<ComponentFramework.Context<IInputs>>();
+        (context as any).page = { entityTypeName: "rbhc_interaction", entityId: rbh_interactionId };
+        context.userSettings = mock<ComponentFramework.UserSettings>();
+        outputChanged = jest.fn(); // mock<() => void>();
+        state = mock<ComponentFramework.Dictionary>();
+
+        document.body.innerHTML = '<div data-testid="container"></div>';
+        container = getByTestId(document.body, "container") as  HTMLDivElement;
+        context.parameters.MinDate = mock<IInputs["MinDate"]>();
+        context.parameters.MaxDate = mock<IInputs["MaxDate"]>();
+        context.parameters.SpecificDateTimeField = mock<IInputs["SpecificDateTimeField"]>();
+        context.parameters.SpecificDateTimeField.raw = null;
+        return [datePicker, context, outputChanged, container];
+    });
+
+    test.each([
+        ["Empty min/max", "", "", undefined, 0, undefined ],
+        ["Absolute min date", "2024-04-03", "", "2024-04-02" , "2024-04-04", undefined ],
+        ["Absolute max date", "", "2024-04-30", undefined , "2024-04-29", "2024-05-01" ],
+        ["Absolute min/max date", "2024-04-03", "2024-05-15", "2024-04-03" , "2024-04-04", "2024-05-15" ],
+        ["Relative min/max date", "-20", "0", -21, -1, +1],
+        ["Relative min/max date - today", "-20", "1", -21 , 0, +10],
+        ["Invalid date", "2024/04/03", "0", -30 , -1 , +1],
+    ])( "%s Min/Max date functions", 
+      async ( description: string, min: string, max: string, 
+        expectedLow: number | string | undefined, expectedOk: number | string | undefined, expectedHigh: number | string | undefined ) => {
+
+        context.parameters.MinDate.raw = min;
+        context.parameters.MaxDate.raw = max;
+        let expectedCalls = 0;
+
+        datePicker.init(context, outputChanged,state, container);
+        context.parameters.SpecificDateTimeField = mock<IInputs["SpecificDateTimeField"]>();
+        context.parameters.SpecificDateTimeField.raw = null;
+        datePicker.updateView(context);
+        // Expect datePicker to be undefined initially.
+        const value1 = datePicker.getOutputs();
+        expect(value1.SpecificDateTimeField).toBeUndefined();
+
+        await userEvent.clear(  getByTestId(container,"time"));       
+        if (expectedLow !== undefined) {
+            // Setting the date to the low value should not change the value.
+            const lowDate = ( expectedLow as number ) ? relativeDate(expectedLow as number) :
+                              expectedLow as string;
+            await userEvent.clear(  getByTestId(container,"date"));
+            await userEvent.click(  getByTestId(container,"date"));
+            await userEvent.type(  getByTestId(container,"date"), lowDate);
+            await waitFor(() => expect( datePicker.getOutputs().SpecificDateTimeField).toBeUndefined());
+            await userEvent.click(getByTestId(container,"time"));
+            await userEvent.type(getByTestId(container,"time"), "12:35");       
+            await waitFor(() => expect( datePicker.getOutputs().SpecificDateTimeField).toBeUndefined());
+            expect(outputChanged).toHaveBeenCalledTimes(0);
+            expectedCalls ++;
+        }
+
+        if (expectedOk !== undefined) {
+            // Setting the date to the low value should not change the value.
+            const okDate = relativeDate(expectedOk);
+            await userEvent.clear(  getByTestId(container,"date"));
+            await userEvent.click(getByTestId(container,"date"));
+            await userEvent.type(  getByTestId(container,"date"), okDate);
+            await userEvent.clear(getByTestId(container,"time"));
+            await userEvent.click(getByTestId(container,"time"));
+            await userEvent.type(getByTestId(container,"time"), "12:35");     
+            await new Promise( (r) => setTimeout(r,500));
+            await waitFor(() => expect( datePicker.getOutputs().SpecificDateTimeField).toEqual( new Date(`${okDate}T12:35`)));
+            expectedCalls++;
+            expect(outputChanged).toHaveBeenCalledTimes(expectedCalls);
+        }
+
+        if (expectedHigh !== undefined) {
+            // Setting the date to the high value should not change the value. This shouldbe rejected.
+            const highDate = relativeDate(expectedHigh);
+            await userEvent.clear(  getByTestId(container,"date"));
+            await userEvent.type(  getByTestId(container,"date"), highDate);
+            await userEvent.click(getByTestId(container,"time"));
+            await userEvent.type(getByTestId(container,"time"), "12:35");       
+            await new Promise( (r) => setTimeout(r,500));
+            await waitFor(() => expect( datePicker.getOutputs().SpecificDateTimeField).toBeUndefined());
+            expectedCalls +=3;
+            expect(outputChanged).toHaveBeenCalledTimes(expectedCalls);
+        }
+
+    },1000*1000);
+})
+
+/**
+ * Converts a parameter that is either a date string or a number offset from now into a date string.
+ * @param offsetDays 
+ * @returns 
+ */
+function relativeDate(offsetDays: number | string ) : string {
+    const date = ( typeof(offsetDays) == 'number' ) ? new Date(Date.now() + (offsetDays as number) * 86400 * 1000).toISOString().split("T")[0] :
+                 offsetDays as string;
+    return date;
+}
+

--- a/SpecificDateTime/tests/SpecificDatePicker4.test.ts
+++ b/SpecificDateTime/tests/SpecificDatePicker4.test.ts
@@ -39,6 +39,7 @@ describe( 'Test min/max date features', () => {
         ["Relative min/max date", "-20", "0", -21, -1, +1],
         ["Relative min/max date - today", "-20", "1", -21 , 0, +10],
         ["Invalid date", "2024/04/03", "0", -30 , -1 , +1],
+        ["Not a date", "val", "val", undefined , 0 , undefined],
     ])( "%s Min/Max date functions", 
       async ( description: string, min: string, max: string, 
         expectedLow: number | string | undefined, expectedOk: number | string | undefined, expectedHigh: number | string | undefined ) => {
@@ -99,6 +100,23 @@ describe( 'Test min/max date features', () => {
             expect(outputChanged).toHaveBeenCalledTimes(expectedCalls);
         }
 
+    },1000*1000);
+
+    test.each( [
+        ['2024-04-12', '2024-05-03', "Enter a date between 12/04/2024 and 03/05/2024"],
+        ['2024-04-12', null, "Enter a date after 12/04/2024"],
+        [null, '2024-05-03', "Enter a date before 03/05/2024"],
+        [null, null, "Enter any valid date"],
+    ])( "Test tooltip format %s/%s", (lowBound:string | null, upperBound: string | null, expected: string ) =>{
+    
+        context.parameters.MinDate.raw = lowBound;
+        context.parameters.MaxDate.raw = upperBound;
+        let expectedCalls = 0;
+    
+        datePicker.init(context, outputChanged,state, container);
+
+        expect( getByTestId(container, "date").getAttribute("title")).toEqual(expected);
+        
     },1000*1000);
 })
 


### PR DESCRIPTION
Add min/max date parameters.
Allow the min and max dates to be either specified with absolute dates, or as an offset in days from the current date.
Add a tooltip to specify the date range allowed in the control